### PR TITLE
Initial/entity mapping

### DIFF
--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/Consultoria.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/Consultoria.java
@@ -1,0 +1,42 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model;
+
+
+import br.com.melhoremcasa.melhor_em_casa_api.model.paciente.Paciente;
+import br.com.melhoremcasa.melhor_em_casa_api.model.usuario.Usuario;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Consultoria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "paciente_id, nullable = false")
+    private Paciente paciente;
+
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(name = "unidade_saude")
+    private String  UnidadeSaude;
+
+    private String equipe;
+
+    @Column(name = "data_consultoria", nullable = false)
+    private LocalDateTime data_consultoria;
+
+    private String solicitante;
+
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/Endereco.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/Endereco.java
@@ -1,0 +1,34 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Endereco {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String estado;
+
+    private String cidade;
+
+    private String bairro;
+
+    private String rua;
+
+    private String numero;
+
+    @Column(name = "ponto_referencia")
+    private String pontoReferencia;
+
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/paciente/Paciente.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/paciente/Paciente.java
@@ -1,0 +1,47 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model.paciente;
+
+
+import br.com.melhoremcasa.melhor_em_casa_api.model.Endereco;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Paciente {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    private TipoPaciente tipoPaciente;
+
+    private String nome;
+
+    @Column(name = "data_nascimento", nullable = false)
+    private LocalDate data_nascimento;
+
+    @Column(unique = true, nullable = false, length = 11)
+    private String cpf;
+
+    private String cid;
+
+    private String telefone;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "endereco_id", referencedColumnName = "id")
+    private Endereco endereco;
+
+    @Column(updatable = false)
+    private LocalDateTime dataCadastro = LocalDateTime.now();
+
+
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/paciente/TipoPaciente.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/paciente/TipoPaciente.java
@@ -1,0 +1,7 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model.paciente;
+
+public enum TipoPaciente {
+    CONSULTORIA,
+    ATIVO,
+    INATIVO
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/TipoEquipeID.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/TipoEquipeID.java
@@ -1,0 +1,7 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model.usuario;
+
+public enum TipoEquipeID {
+    MEDICO,
+    ENFERMEIRO,
+    TEC_ENFERMAGEM
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/TipoUsuario.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/TipoUsuario.java
@@ -1,0 +1,19 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model.usuario;
+
+
+public enum TipoUsuario {
+
+    ADMINISTRADOR(null),
+    MOTORISTA(null);
+
+    private final TipoEquipeID tipoEquipeID;
+
+    TipoUsuario(TipoEquipeID tipoEquipeID) {
+        this.tipoEquipeID = tipoEquipeID;
+    }
+
+    public TipoEquipeID getTipoEquipeID() {
+        return tipoEquipeID;
+    }
+
+}

--- a/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/Usuario.java
+++ b/src/main/java/br/com/melhoremcasa/melhor_em_casa_api/model/usuario/Usuario.java
@@ -1,0 +1,35 @@
+package br.com.melhoremcasa.melhor_em_casa_api.model.usuario;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Usuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String nome;
+
+    @Column(unique = true, nullable = false)
+    private String login;
+
+    @Column(nullable = false)
+    private String senha;
+
+    @Column(unique = true, nullable = false, length = 11)
+    private String cpf;
+
+    @Enumerated(EnumType.STRING)
+    private TipoUsuario tipoUsuario;
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
-spring.application.name=melhor-em-casa-api
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=user
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Este PR implementa o mapeamento inicial das entidades do projeto, definindo as principais classes do domínio e suas respectivas anotações JPA. Foram criadas e configuradas as seguintes entidades:

Paciente → Representa o paciente do sistema, incluindo atributos como nome, CPF, data de nascimento, telefone, endereço, entre outros.

Usuario → Define os usuários do sistema, armazenando informações como nome, login, senha, CPF e tipo de usuário.

Endereco → Estrutura para armazenar informações de endereço, como estado, cidade, bairro, rua e número.

Consultoria → Representa uma consulta ou atendimento, relacionando um paciente a um usuário e armazenando informações sobre a equipe de saúde envolvida.

Além disso, foram criadas as enums para categorização:

TipoUsuario → Define os tipos de usuário no sistema (ADMINISTRADOR, MOTORISTA).
TipoEquipeID → Representa diferentes categorias dentro da equipe de saúde (MEDICO, ENFERMEIRO, TEC_ENFERMAGEM).